### PR TITLE
Fix: Сумма не отображалась на странице оплтаты

### DIFF
--- a/pyqiwi/util.py
+++ b/pyqiwi/util.py
@@ -56,7 +56,7 @@ def split_float(amount: float):
         params['amountInteger'] = str(amount).split('.')[0]
         params['amountFraction'] = str(amount).split('.')[1]
     else:
-        params['amountInteger'] = amount
+        params['amount'] = amount
     return params
 
 def merge_dicts(x, y):


### PR DESCRIPTION
Если передать `amount` c типом `int` то сумма не отображалась на странице оплаты.
Проблема заключалась в том что Qiwi не использовал `amountInteger` без указания `amountFraction`.
Предложенный pull request исправляет проблему.
Теперь используется поддерживаемый Qiwi URL параметр `amount`.